### PR TITLE
fixed old API Call Engine -> router

### DIFF
--- a/fluent-plugin-mysqlslowquerylog.gemspec
+++ b/fluent-plugin-mysqlslowquerylog.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency "fluentd"
-  gem.add_runtime_dependency "fluentd"
+  gem.add_development_dependency "fluentd", ">= 0.12.0"
+  gem.add_runtime_dependency "fluentd", ">= 0.12.0"
 end

--- a/lib/fluent/plugin/out_mysqlslowquerylog.rb
+++ b/lib/fluent/plugin/out_mysqlslowquerylog.rb
@@ -78,7 +78,7 @@ class Fluent::MySQLSlowQueryLogOutput < Fluent::Output
     _tag = tag.clone
     filter_record(_tag, time, record)
     if tag != _tag
-      Fluent::Engine.emit(_tag, time, record)
+      router.emit(_tag, time, record)
     else
       $log.warn "Can not emit message because the tag has not changed. Dropped record #{record}"
     end


### PR DESCRIPTION
https://github.com/fluent/fluentd/issues/1041
> In v0.12 and v0.14, plugin should use router.emit, not Engine.emit.